### PR TITLE
fix: prevent connection leak when RESET app.tenant_id fails in TenantAwareDataSource

### DIFF
--- a/src/main/kotlin/com/github/atrifyllis/multitenancy/adapters/secondary/persistence/TenantAwareDataSource.kt
+++ b/src/main/kotlin/com/github/atrifyllis/multitenancy/adapters/secondary/persistence/TenantAwareDataSource.kt
@@ -1,6 +1,7 @@
 package com.github.atrifyllis.multitenancy.adapters.secondary.persistence
 
 import com.github.atrifyllis.multitenancy.application.service.TenantContext
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
@@ -9,6 +10,8 @@ import java.sql.SQLException
 import java.util.*
 import javax.sql.DataSource
 import org.springframework.jdbc.datasource.DelegatingDataSource
+
+private val logger = KotlinLogging.logger {}
 
 /** Tenant-Aware Datasource that decorates Connections with current tenant information. */
 class TenantAwareDataSource(private val targetDataSource: DataSource) :
@@ -55,7 +58,12 @@ class TenantAwareDataSource(private val targetDataSource: DataSource) :
         @Throws(Throwable::class)
         override fun invoke(proxy: Any, method: Method, args: Array<Any>?): Any? {
             if (method.name == "close") {
-                clearTenantId(target)
+                try {
+                    clearTenantId(target)
+                } catch (e: Exception) {
+                    logger.error(e) { "Failed to RESET app.tenant_id; connection may carry stale tenant context" }
+                }
+                return method.invoke(target, *(args ?: emptyArray()))
             }
             return method.invoke(target, *(args ?: emptyArray()))
         }

--- a/src/test/kotlin/com/github/atrifyllis/multitenancy/adapters/secondary/persistence/TenantAwareDataSourceConnectionLeakTest.kt
+++ b/src/test/kotlin/com/github/atrifyllis/multitenancy/adapters/secondary/persistence/TenantAwareDataSourceConnectionLeakTest.kt
@@ -1,0 +1,49 @@
+package com.github.atrifyllis.multitenancy.adapters.secondary.persistence
+
+import com.github.atrifyllis.multitenancy.application.service.TenantContext
+import java.sql.SQLException
+import java.sql.Statement
+import java.util.*
+import javax.sql.DataSource
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+/** Unit test for connection-leak bug in TenantAwareDataSource. No Docker/Testcontainers required. */
+class TenantAwareDataSourceConnectionLeakTest {
+
+    @AfterEach
+    fun tearDown() {
+        TenantContext.clear()
+    }
+
+    @Test
+    fun `close() is called on underlying connection even when RESET throws`() {
+        // Arrange: first createStatement() succeeds (SET), second throws (RESET)
+        val setStatement = mock(Statement::class.java)
+        val resetStatement = mock(Statement::class.java)
+        Mockito.`when`(resetStatement.execute(anyString()))
+            .thenThrow(SQLException("Simulated RESET failure"))
+
+        val mockConn = mock(java.sql.Connection::class.java)
+        Mockito.`when`(mockConn.createStatement())
+            .thenReturn(setStatement)   // first call → SET succeeds
+            .thenReturn(resetStatement) // second call → RESET throws
+
+        val mockDs = mock(DataSource::class.java)
+        Mockito.`when`(mockDs.connection).thenReturn(mockConn)
+
+        TenantContext.setTenantId(UUID.randomUUID())
+        val ds = TenantAwareDataSource(mockDs)
+        val proxyConn = ds.connection // triggers SET — succeeds
+
+        // Act + Assert: close() must not propagate the RESET exception,
+        // AND the real connection.close() must still be called.
+        assertThatCode { proxyConn.close() }.doesNotThrowAnyException()
+        verify(mockConn).close()
+    }
+}


### PR DESCRIPTION
The proxy close() handler now wraps clearTenantId() in a try-catch so the
real connection.close() always executes even if RESET throws. Also adds a
failing-first unit test (TenantAwareDataSourceConnectionLeakTest) that
demonstrates the bug before the fix and passes after it.

Adds pluginManagement { mavenCentral() } to settings.gradle.kts so
Kotlin/Spring plugin artifacts resolve via Maven Central instead of the
blocked plugins-artifacts.gradle.org.

https://claude.ai/code/session_01PJd6aJnw5A2Mgb6eA4GdLM